### PR TITLE
Optimize AbstractBytes initialization

### DIFF
--- a/core/src/main/java/com/avast/bytes/AbstractBytes.java
+++ b/core/src/main/java/com/avast/bytes/AbstractBytes.java
@@ -1,16 +1,16 @@
 package com.avast.bytes;
 
 public abstract class AbstractBytes implements Bytes {
-    private final int TO_STRING_SIZE_LIMIT = 100;
-    private final String IMPLEMENTATION_CLASS_NAME = this.getClass().getCanonicalName();
+
+    private static final int TO_STRING_SIZE_LIMIT = 100;
 
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append(IMPLEMENTATION_CLASS_NAME).append("(");
+        b.append(implementationClassName()).append("(");
         b.append("size:").append(size()).append(", ");
         b.append("bytes: ");
-        if(size() > TO_STRING_SIZE_LIMIT) {
+        if (size() > TO_STRING_SIZE_LIMIT) {
             b.append(view(0, TO_STRING_SIZE_LIMIT).toHexString()).append("...");
         } else {
             b.append(toHexString());
@@ -64,4 +64,9 @@ public abstract class AbstractBytes implements Bytes {
 
         return h;
     }
+
+    private String implementationClassName() {
+        return this.getClass().getCanonicalName();
+    }
+
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Current implementation was calling getClass().getCanonicalName() for each
created AbstractBytes instance. This has a performance impact even though
the class name is only needed for the toString() method implementation.
toString() is usually needed only for debugging so this changes it so that
the performance impact is hit only when toString() is called.

Also TO_STRING_SIZE_LIMIT was made static (saves memory) and Gradle Wrapper
was upgraded to version 3.3.