### PR TITLE
Implement Hex methods

### DIFF
--- a/core/src/main/java/com/avast/bytes/Bytes.java
+++ b/core/src/main/java/com/avast/bytes/Bytes.java
@@ -21,27 +21,6 @@ import java.nio.charset.StandardCharsets;
 public interface Bytes {
 
     /**
-     * Hidden class with private fields and methods. The only reason for an existence of this class is
-     * that Interfaces in jdk8 don't support private methods and fields
-     */
-    class Hidden {
-        private static final char[] hexCode = "0123456789ABCDEF".toCharArray();
-
-        private static int hexToBin(char ch) {
-            if ('0' <= ch && ch <= '9') {
-                return ch - '0';
-            }
-            if ('A' <= ch && ch <= 'F') {
-                return ch - 'A' + 10;
-            }
-            if ('a' <= ch && ch <= 'f') {
-                return ch - 'a' + 10;
-            }
-            return -1;
-        }
-    }
-
-    /**
      * Empty {@link Bytes}.
      */
     static Bytes empty() {
@@ -104,17 +83,17 @@ public interface Bytes {
      * Converts content of this {@link Bytes} to hex string. It uses data provided by `toByteArray`, which means it probably
      * creates a copy of the data (but that depends on the implementation of the `toByteArray`).
      *
-     * Note: Implementation was copied from javax.xml.bind package because the package is no longer supported in jdk11
+     * Note: Implementation was copied from avast.utils.ByteUtils
      * @return hex string representation
      */
     default String toHexString() {
-        byte[] data = toByteArray();
-        StringBuilder r = new StringBuilder(data.length * 2);
-        for (byte b : data) {
-            r.append(Hidden.hexCode[(b >> 4) & 0xF]);
-            r.append(Hidden.hexCode[(b & 0xF)]);
+        byte[] arr = toByteArray();
+        char[] result = new char[arr.length * 2];
+        for (int i = 0; i < arr.length; ++i) {
+            result[i * 2] = Constants.HEX_ARRAY[(arr[i] >> 4) & 0xF];
+            result[i * 2 + 1] = Constants.HEX_ARRAY[(arr[i] & 0xF)];
         }
-        return r.toString().toLowerCase();
+        return new String(result);
     }
 
     /**
@@ -217,24 +196,22 @@ public interface Bytes {
 
     /**
      * Convenience method for creating {@link Bytes} from HEX {@link String}.
-     * Note: Implementation was copied from javax.xml.bind package because the package is no longer supported in jdk11
      */
     static Bytes copyFromHex(String hexString) {
-        final int len = hexString.length();
-        // "111" is not a valid hex encoding.
-        if (len % 2 != 0) {
-            throw new IllegalArgumentException("hexBinary needs to be even-length: " + hexString);
+        final int length = hexString.length();
+        if (length % 2 != 0) {
+            throw new IllegalArgumentException("HexString needs to be even-length: " + hexString);
         }
-        byte[] out = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            int h = Hidden.hexToBin(hexString.charAt(i));
-            int l = Hidden.hexToBin(hexString.charAt(i + 1));
-            if (h == -1 || l == -1) {
-                throw new IllegalArgumentException("contains illegal character for hexBinary: " + hexString);
+        byte[] result = new byte[length / 2];
+        for (int i = 0; i < length; i += 2) {
+            int high = Character.getNumericValue(hexString.charAt(i));
+            int low = Character.getNumericValue(hexString.charAt(i + 1));
+            if (high == -1 || low == -1) {
+                throw new IllegalArgumentException("HexString contains illegal characters: " + hexString);
             }
-            out[i / 2] = (byte) (h * 16 + l);
+            result[i / 2] = (byte) (high * 16 + low);
         }
-        return copyFrom(out);
+        return copyFrom(result);
     }
 
 

--- a/core/src/main/java/com/avast/bytes/Constants.java
+++ b/core/src/main/java/com/avast/bytes/Constants.java
@@ -1,0 +1,5 @@
+package com.avast.bytes;
+
+class Constants {
+    static final char[] HEX_ARRAY = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
* Previous calling of package javax.xml.bind is no longer supported in jdk11
* Copy implementation from DatatypeConverterImpl straight to Bytes interface